### PR TITLE
Feat conteinerização, close #45

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+
+WORKDIR /app
+
+COPY .  .
+
+RUN npm install --quiet --no-optional --no-fund --loglevel=error 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   - [Tecnologias](#tecnologias)
 - [Executando o Projeto](#executando-o-projeto)
   - [Dependências](#dependências)
-  - [Rodando localmente](#rodando-localmente)
+  - [Modo produção](#modo-produção)
+  - [Modo desenvolvimento](#modo-desenvolvimento)
 - [Autores](#autores)
   - [Equipe 1º/2023](#equipe-12023)
 
@@ -52,7 +53,42 @@ Antes de começar, certifique-se de ter as seguintes ferramentas instaladas em s
 - Node.js: [Instalação do Node.js](https://nodejs.org/)
 - Docker: [Instalação do Docker](https://docs.docker.com/desktop/install/linux-install/)
 
-## Rodando localmente
+## Modo produção
+
+Clone o projeto:
+
+```bash
+git clone https://github.com/fabrica-bayarea/prontuario-back.git
+```
+
+Navegue para a pasta recém-criada:
+
+```bash
+cd prontuario-back 
+```
+
+Crie um arquivo .env na raíz do projeto e adicione as seguintes variáveis de ambiente:
+
+```env
+DATABASE_URL="postgresql://usuario_postgres:senha_postgres@postgres:5432/db_postgres?schema=public"
+JWT_SECRET="seu segredo"
+POSTGRES_USER=usuario_postgres
+POSTGRES_PASSWORD=senha_postgres
+POSTGRES_DB=db_postgres
+```
+
+Suba o sistema inteiro
+
+```bash
+docker compose up -d
+```
+
+> [!NOTE]  
+> No modo produção não é necessario instalar pacotes ou fazer migração no prisma, todo o sistema está configurado no docker compose!
+
+## Modo desenvolvimento
+
+No modo desenvolvimento sobe apenas o container postgres no docker compose, a api continua local para o desenvolvimento.
 
 Clone o projeto:
 
@@ -74,24 +110,26 @@ npm install
 
 Crie um arquivo .env na raíz do projeto e adicione as seguintes variáveis de ambiente:
 
-```sh
-DATABASE_URL="postgresql://usuario:senha@host:port/nome_do_banco?schema=nome_do_schema"
+```env
+DATABASE_URL="postgresql://usuario_postgres:senha_postgres@localhost:5435/db_postgres?schema=public"
 JWT_SECRET="seu segredo"
 POSTGRES_USER=usuario_postgres
 POSTGRES_PASSWORD=senha_postgres
 POSTGRES_DB=db_postgres
 ```
 
+> [!IMPORTANT]  
+> No modo produção na variavel de ambiente DATABASE_URL o host:port  é `postgres:5432`, mas no modo desenvolvimento deve ser `localhost:5435`
+
 Suba o banco de dados com o docker:
 
-```sh
-docker-compose up -d
-
+```bash
+docker-compose -f docker-compose-dev.yml -d
 ```
 
 Aplique as migrações necessárias:
 
-```sh
+```bash
 npx prisma migrate dev
 ```
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,15 @@
+services:
+  postgres-dev:
+    image: 'postgres:14.5'
+    container_name: prontario-dev-postgres
+    restart: always
+    env_file:
+      - .env
+    logging:
+      options:
+        max-size: 10m
+        max-file: "3"
+    ports:
+      - '5435:5432'
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,30 @@
-version: '3'
 services:
   postgres:
     image: 'postgres:14.5'
+    container_name: prontario-postgres
+    restart: always
+    env_file:
+      - .env
+    logging:
+      options:
+        max-size: 10m
+        max-file: "3"
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB} -h localhost"]
+      interval: 2s
+      timeout: 3s
+      retries: 5  
+
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: prontario-api
+    command: ["sh", "-c", "npx prisma migrate deploy && npm run build && npm run start:prod"]
     restart: always
     env_file:
       - .env
@@ -10,8 +33,19 @@ services:
         max-size: 10m
         max-file: "3"
     ports:
-      - '5444:5432'
-    volumes:
-      - ./postgres-data:/var/lib/postgresql/data
-      - ./sql/users.sql:/docker-entrypoint-initdb.d/create_tables.sql
+      - '3000:3000'
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3 
+      start_period: 30s 
 
+networks:
+  app-network:
+    driver: bridge

--- a/prisma/migrations/20240927014139_novas_colunas_usuario_programa_curso/migration.sql
+++ b/prisma/migrations/20240927014139_novas_colunas_usuario_programa_curso/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - Added the required column `coordenador` to the `Curso` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `turno` to the `Curso` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `descricao` to the `Programa` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `horario` to the `Programa` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `inicio` to the `Programa` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `publicoAlvo` to the `Programa` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `termino` to the `Programa` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `cep` to the `Usuario` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `cidade` to the `Usuario` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `endereco` to the `Usuario` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `sobrenome` to the `Usuario` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "Turnos" AS ENUM ('Matutino', 'Vespertino', 'Noturno', 'Integral');
+
+-- AlterTable
+ALTER TABLE "Curso" ADD COLUMN     "coordenador" TEXT NOT NULL,
+ADD COLUMN     "turno" "Turnos" NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Programa" ADD COLUMN     "descricao" TEXT NOT NULL,
+ADD COLUMN     "horario" TEXT NOT NULL,
+ADD COLUMN     "inicio" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "publicoAlvo" TEXT NOT NULL,
+ADD COLUMN     "termino" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Usuario" ADD COLUMN     "cep" TEXT NOT NULL,
+ADD COLUMN     "cidade" TEXT NOT NULL,
+ADD COLUMN     "endereco" TEXT NOT NULL,
+ADD COLUMN     "sobrenome" TEXT NOT NULL;

--- a/src/curso/curso.dto.ts
+++ b/src/curso/curso.dto.ts
@@ -1,16 +1,22 @@
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, IsEnum } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
+export type Turnos = 'Matutino' | 'Vespertino' | 'Noturno' | 'Integral';
+const Turnos: Turnos[] = ['Matutino', 'Vespertino', 'Noturno', 'Integral'];
 export class CreateCursoDto {
   @ApiProperty({ example: 'Ciência da Computação' })
   @IsString()
   @IsNotEmpty()
   nome: string;
 
-  @ApiProperty({ example: 'Matutino, Vespertino, Nortuno ou Integral' })
-  @IsString()
-  @IsNotEmpty()
-  turno: string;
+  @ApiProperty({
+    enum: ['Matutino', 'Vespertino', 'Noturno', 'Integral'],
+    example: 'Matutino',
+  })
+  @IsEnum(Turnos, {
+    message: 'O turno deve ser Matutino, Vespertino, Noturno ou Integral',
+  })
+  turno: Turnos;
 
   @ApiProperty({ example: 'João Silva' })
   @IsString()
@@ -24,10 +30,14 @@ export class UpdateCursoDto {
   @IsNotEmpty()
   nome: string;
 
-  @ApiProperty({ example: 'Matutino, Vespertino, Nortuno ou Integral' })
-  @IsString()
-  @IsNotEmpty()
-  turno: string;
+  @ApiProperty({
+    enum: ['Matutino', 'Vespertino', 'Noturno', 'Integral'],
+    example: 'Matutino',
+  })
+  @IsEnum(Turnos, {
+    message: 'O turno deve ser Matutino, Vespertino, Noturno ou Integral',
+  })
+  turno: Turnos;
 
   @ApiProperty({ example: 'João Silva' })
   @IsString()

--- a/src/curso/curso.service.ts
+++ b/src/curso/curso.service.ts
@@ -31,7 +31,7 @@ export class CursoService {
     });
 
     if (repetido) {
-      throw new BadRequestException('nome do curso deve ser único')
+      throw new BadRequestException('nome do curso deve ser único');
     }
 
     return this.prisma.curso.create({


### PR DESCRIPTION
Agora teremos dois docker compose:

- docker-compose.yml - É para o "Deploy", sobe o contêiner da Api e do Postgres, em modo de produção e com checagem de saúde, além que, não é necessário instalar pacotes e fazer migrate manualmente, todo esse processo de preparação de ambiente é feito pelo docker, sendo necessário só inserir variáveis de ambiente.

- docker-compose-dev.yml - Seria o equivalente ao jeito antigo, sobe apenas o Postgres, mas mantém a Api de forma local para o desenvolvimento.